### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   monzo-credit-card-pot-sync:
     image: ghcr.io/mattgogerly/monzo-credit-card-pot-sync:latest


### PR DESCRIPTION
Docker Compose Version tag is no longer used and legacy.